### PR TITLE
Adjusted mario joystick movement to be 75%, matching that of original…

### DIFF
--- a/src/game/game_init.c
+++ b/src/game/game_init.c
@@ -381,19 +381,19 @@ void adjust_analog_stick(struct Controller *controller) {
 
     // modulate the rawStickX and rawStickY to be the new f32 values by adding/subtracting 6.
     if (controller->rawStickX <= -8) {
-        controller->stickX = controller->rawStickX + 6;
+        controller->stickX = controller->rawStickX * 0.75f + 6;
     }
 
     if (controller->rawStickX >= 8) {
-        controller->stickX = controller->rawStickX - 6;
+        controller->stickX = controller->rawStickX * 0.75f - 6;
     }
 
     if (controller->rawStickY <= -8) {
-        controller->stickY = controller->rawStickY + 6;
+        controller->stickY = controller->rawStickY * 0.75f + 6;
     }
 
     if (controller->rawStickY >= 8) {
-        controller->stickY = controller->rawStickY - 6;
+        controller->stickY = controller->rawStickY * 0.75f - 6;
     }
 
     // calculate f32 magnitude from the center by vector length.


### PR DESCRIPTION
… optical encoding disk joysticks range

The joystick is set to use a modern range, not the limited range of around 70ish % from a new N64 controller of the age for which this game was designed for.

I think this change improves the precision and experience when controlling the acrobat plumber, based on Vita 1000 joystick.